### PR TITLE
[Xamarin.Forms.Mocks] use 3.5.0.2

### DIFF
--- a/Source/TailwindTraders.Mobile/UnitTests/UnitTests.csproj
+++ b/Source/TailwindTraders.Mobile/UnitTests/UnitTests.csproj
@@ -12,7 +12,7 @@
     <PackageReference Include="NUnit" Version="3.11.0" />
     <PackageReference Include="NUnit3TestAdapter" Version="3.13.0" />
     <PackageReference Include="Refit" Version="4.6.107" />
-    <PackageReference Include="Xamarin.Forms.Mocks" Version="4.0.0-pre1" />
+    <PackageReference Include="Xamarin.Forms.Mocks" Version="3.5.0.2" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
4.0.0-pre1 is unlisted now, so this should use the newer release that supports a wider range of Xamarin.Forms versions.

The `BaseContentPageTests` still pass for me after this change :thumbsup: